### PR TITLE
Fix flakiness in test in `standalone-metastore`

### DIFF
--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/utils/TestMetaStoreServerUtils.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/utils/TestMetaStoreServerUtils.java
@@ -774,9 +774,13 @@ public class TestMetaStoreServerUtils {
     p3.unsetSd();
     List<PartitionSpec> result =
         MetaStoreServerUtils.getPartitionspecsGroupedByStorageDescriptor(tbl,
-            Arrays.asList(p1, p2, p3, p4));
+            Arrays.asList(p1, p2, p3, p4))
+                .stream().sorted().collect(Collectors.toList());
     assertThat(result.size(), is(3));
-    PartitionSpec ps1 = result.get(0);
+    PartitionSpec ps1 = result.get(1);
+    PartitionSpec ps2 = result.get(2);
+    PartitionSpec ps4 = result.get(0);
+
     assertThat(ps1.getRootPath(), is((String)null));
     assertThat(ps1.getPartitionList(), is((List<Partition>)null));
     PartitionSpecWithSharedSD partSpec = ps1.getSharedSDPartitionSpec();
@@ -786,7 +790,6 @@ public class TestMetaStoreServerUtils {
     assertThat(partition1.getRelativePath(), is((String)null));
     assertThat(partition1.getValues(), is(Collections.singletonList("val3")));
 
-    PartitionSpec ps2 = result.get(1);
     assertThat(ps2.getRootPath(), is(tbl.getSd().getLocation()));
     assertThat(ps2.getPartitionList(), is((List<Partition>)null));
     List<PartitionWithoutSD> partitions2 = ps2.getSharedSDPartitionSpec().getPartitions();
@@ -804,7 +807,6 @@ public class TestMetaStoreServerUtils {
     assertThat(partition2_2.getRelativePath(), is("/baz"));
     assertThat(partition2_2.getValues(), is(Collections.singletonList("val4")));
 
-    PartitionSpec ps4 = result.get(2);
     assertThat(ps4.getRootPath(), is((String)null));
     assertThat(ps4.getSharedSDPartitionSpec(), is((PartitionSpecWithSharedSD)null));
     List<Partition>partitions = ps4.getPartitionList().getPartitions();


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?

The test method `org.apache.hadoop.hive.metastore.utils.TestMetaStoreServerUtils.testGetPartitionspecsGroupedBySDonePartitionCombined` creates a `List<PartitionSpec>` that was order-unstable under [NonDex](https://github.com/TestingResearchIllinois/NonDex); sorting it ensures that the partitions are in a known order while preserving the intent of the test.


### Why are the changes needed?

This test passes as is, but if the implementation of `MetaStoreServerUtils.getPartitionspecsGroupedByStorageDescriptor` were to ever change order, even implicitly through a changed dependency, then the test would break.  This PR fixes the test to no longer depend on the order of partitions returned.

### Does this PR introduce _any_ user-facing change?

No; this only alters one test, that was already passing normally, to additionally pass if the latent order-instability ends up happening in practice.


### How was this patch tested?

The test itself was run before alteration, both normally (to ensure it already passed) and with NonDex (to confirm the flakiness); it was then run again in both ways after alteration, at which point both normal and NonDex runs passed, including over 150 different seeds for the latter.
